### PR TITLE
Fixed issue when selecting records based on a column having a null value

### DIFF
--- a/MicroOrm.Pocos.SqlGenerator.Tests/MicroOrm.Pocos.SqlGenerator.Tests.csproj
+++ b/MicroOrm.Pocos.SqlGenerator.Tests/MicroOrm.Pocos.SqlGenerator.Tests.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8628CB78-2226-4AFA-B0FF-8015D56AC9C9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MicroOrm.Pocos.SqlGenerator.Tests</RootNamespace>
+    <AssemblyName>MicroOrm.Pocos.SqlGenerator.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="SqlGeneratorTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MicroOrm.Pocos.SqlGenerator\MicroOrm.Pocos.SqlGenerator.csproj">
+      <Project>{37efd853-cbff-4b7f-9568-615747ca7237}</Project>
+      <Name>MicroOrm.Pocos.SqlGenerator</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MicroOrm.Pocos.SqlGenerator.Tests/Properties/AssemblyInfo.cs
+++ b/MicroOrm.Pocos.SqlGenerator.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MicroOrm.Pocos.SqlGenerator.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MicroOrm.Pocos.SqlGenerator.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8628cb78-2226-4afa-b0ff-8015d56ac9c9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MicroOrm.Pocos.SqlGenerator.Tests/SqlGeneratorTests.cs
+++ b/MicroOrm.Pocos.SqlGenerator.Tests/SqlGeneratorTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MicroOrm.Pocos.SqlGenerator.Attributes;
+
+namespace MicroOrm.Pocos.SqlGenerator.Tests
+{
+    [TestClass]
+    public class SqlGeneratorTests
+    {
+        [TestMethod]
+        public void GetWhere_TestForNulls()
+        {
+            var sqlGenerator = new SqlGenerator<MyObject>();
+
+            var sql = sqlGenerator.GetSelect(new { Disabled = (DateTime?)null });
+
+            Assert.IsTrue(sql.Contains("WHERE [MyTable].[Disabled] IS NULL"), sql);
+        }
+
+        [TestMethod]
+        public void GetWhere_TestForValueInNullableColumn()
+        {
+            var sqlGenerator = new SqlGenerator<MyObject>();
+
+            var sql = sqlGenerator.GetSelect(new { Disabled = new DateTime(2016,02,04,0,0,0) });
+
+            Assert.IsTrue(sql.Contains("WHERE [MyTable].[Disabled] = @Disabled"), sql);
+        }
+    }
+
+    [StoredAs("MyTable")]
+    public class MyObject
+    {
+        [KeyProperty]
+        public int MyObjectId { get; set; }
+
+        public string Description { get; set; }
+
+        public DateTime? Disabled { get; set; }
+    }
+}

--- a/MicroOrm.Pocos.SqlGenerator.sln
+++ b/MicroOrm.Pocos.SqlGenerator.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 2013 for Web
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroOrm.Pocos.SqlGenerator", "MicroOrm.Pocos.SqlGenerator\MicroOrm.Pocos.SqlGenerator.csproj", "{37EFD853-CBFF-4B7F-9568-615747CA7237}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroOrm.Pocos.SqlGenerator.Tests", "MicroOrm.Pocos.SqlGenerator.Tests\MicroOrm.Pocos.SqlGenerator.Tests.csproj", "{8628CB78-2226-4AFA-B0FF-8015D56AC9C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{37EFD853-CBFF-4B7F-9568-615747CA7237}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{37EFD853-CBFF-4B7F-9568-615747CA7237}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{37EFD853-CBFF-4B7F-9568-615747CA7237}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8628CB78-2226-4AFA-B0FF-8015D56AC9C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8628CB78-2226-4AFA-B0FF-8015D56AC9C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8628CB78-2226-4AFA-B0FF-8015D56AC9C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8628CB78-2226-4AFA-B0FF-8015D56AC9C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
You can now select records based on a null column value.  
Added tests to support this and ensure existing select functionality wasn't knocked
out.