### PR TITLE
Add select where IN @param

### DIFF
--- a/MicroOrm.Pocos.SqlGenerator.Tests/SqlGeneratorTests.cs
+++ b/MicroOrm.Pocos.SqlGenerator.Tests/SqlGeneratorTests.cs
@@ -46,6 +46,15 @@ namespace MicroOrm.Pocos.SqlGenerator.Tests
 
             Assert.IsTrue(sql.StartsWith("SELECT [MyTable].[MyObjectId]"), sql);
         }
+
+        [TestMethod]
+        public void GetWhere_TestIEnumerableFilter()
+        {
+            var sqlGenerator = new SqlGenerator<MyObject>();
+            var sql = sqlGenerator.GetSelect(new { Description = new[] { "a", "b", "c" } });
+
+            Assert.IsTrue(sql.Contains("WHERE [MyTable].[Description] IN @Description"));
+        }
     }
 
     [StoredAs("MyTable")]

--- a/MicroOrm.Pocos.SqlGenerator/SqlGenerator.cs
+++ b/MicroOrm.Pocos.SqlGenerator/SqlGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using MicroOrm.Pocos.SqlGenerator.Attributes;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -300,9 +301,15 @@ namespace MicroOrm.Pocos.SqlGenerator
                     propertyName = propertyMetadata.Name;
                 }
 
-                if (filters.GetType().GetProperty(propertyMetadata.Name).GetValue(filters, null) == null)
+                var values = filters.GetType().GetProperty(propertyMetadata.Name).GetValue(filters, null);
+
+                if (values == null)
                 {
                     return string.Format("[{0}].[{1}] IS NULL", this.TableName, columnName);
+                }
+                else if(values is IEnumerable)
+                {
+                    return string.Format("[{0}].[{1}] IN @{2}", this.TableName, columnName, propertyName);
                 }
                 else {
                     return string.Format("[{0}].[{1}] = @{2}", this.TableName, columnName, propertyName);


### PR DESCRIPTION
SqlGenerator can now format SELECT statements where the parameter provides an `IEnumerable`.  For example,

    GetSelect(new{ Description = new[]{a, b, c} });

Becomes

    SELECT * FROM table WHERE Description IN @Description